### PR TITLE
add stopPropagation to prevent clicks on marker from bubbling to map

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = ({
 				this.div.innerHTML = this.html;
 			}
 			google.maps.event.addDomListener(this.div, "click", event => {
+				event.stopPropagation()
 				google.maps.event.trigger(this, "click");
 			});
 		}


### PR DESCRIPTION
Thanks for this useful and convenient script,

I simply added .stopPropagation() so the click event didn't bubble up to the map.

Kind regards